### PR TITLE
SDPMVP-27202 dtmf begin fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 *.orig
 tests/CI/output
 .develvars
+.idea/

--- a/include/asterisk/channel.h
+++ b/include/asterisk/channel.h
@@ -4186,6 +4186,10 @@ enum ama_flags ast_channel_amaflags(const struct ast_channel *chan);
 /*!
  * \pre chan is locked
  */
+
+int ast_channel_avoxi_purge_packets(const struct ast_channel *chan);
+void ast_channel_avoxi_purge_packets_set(struct ast_channel *chan, int value);
+
 void ast_channel_amaflags_set(struct ast_channel *chan, enum ama_flags value);
 int ast_channel_epfd(const struct ast_channel *chan);
 void ast_channel_epfd_set(struct ast_channel *chan, int value);

--- a/main/channel_internal_api.c
+++ b/main/channel_internal_api.c
@@ -224,7 +224,19 @@ struct ast_channel {
 	struct ast_stream *default_streams[AST_MEDIA_TYPE_END]; /*!< Default streams indexed by media type */
 	struct ast_channel_snapshot *snapshot; /*!< The current up to date snapshot of the channel */
 	struct ast_flags snapshot_segment_flags; /*!< Flags regarding the segments of the snapshot */
+
+	int avoxi_purge_packets; /*!< If set first ast_read will exhaust the socket buffer, initialized to zero at alloc */
 };
+
+int ast_avoxi_purge_packets(const struct ast_channel *chan)
+{
+	return chan->avoxi_purge_packets;
+}
+
+void ast_avoxi_purge_packets_set(struct ast_channel *chan, int value)
+{
+	chan->avoxi_purge_packets = value;
+}
 
 /*! \brief The monotonically increasing integer counter for channel uniqueids */
 static int uniqueint;

--- a/res/res_pjsip_sdp_rtp.c
+++ b/res/res_pjsip_sdp_rtp.c
@@ -557,6 +557,9 @@ static int set_caps(struct ast_sip_session *session,
 
 	if (session->channel && ast_sip_session_is_pending_stream_default(session, asterisk_stream)) {
 		ast_channel_lock(session->channel);
+		ast_log(LOG_DEBUG, "AVOXI: set_caps(): Ch=%s %s Setting purge flag\n",
+				ast_channel_name(session->channel), ast_sip_session_get_name(session));
+		ast_avoxi_purge_packets_set(session->channel, 1);
 		ast_format_cap_remove_by_type(caps, AST_MEDIA_TYPE_UNKNOWN);
 		ast_format_cap_append_from_cap(caps, ast_channel_nativeformats(session->channel),
 			AST_MEDIA_TYPE_UNKNOWN);


### PR DESCRIPTION
- Don't emit extra dtmf begin packets (Looks like a bug)
- Don't emit in-between dtmf events, another bug causes asterisk to send a continuation event for the first dtmf end event. Now we are only emitting first two dtmf packets.